### PR TITLE
feat: support all different info strings for fenced code blocks.

### DIFF
--- a/md_snakeoil/apply.py
+++ b/md_snakeoil/apply.py
@@ -89,7 +89,7 @@ class Formatter:
         # look for ```python or ```py code blocks
         # works with attributes like ```python title="example" ... as well
         # and handle indentation
-        pattern = r"([ \t]*)(```(?:python| python|py| py)(?:[^\n]*)\n)(.*?)([ \t]*```)"  # noqa: E501
+        pattern = r"([ \t]*)(```(?:python| python|py| py|Python| Python)(?:[^\n]*)\n)(.*?)([ \t]*```)"  # noqa: E501
 
         matches = list(re.finditer(pattern, content, re.DOTALL))
         if len(matches) == 0:

--- a/tests/info_strings.md
+++ b/tests/info_strings.md
@@ -1,0 +1,17 @@
+File with fenced code blocks with different info strings for language types.
+
+```python
+x=[1,2,3]
+```
+
+```py
+y=[4,5,6]
+```
+
+```Python
+z=[7,8,9]
+```
+
+```python startline=3 $%@#$
+a=[10,11,12]
+```

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -77,3 +77,15 @@ def test_different_indentation_levels():
 
     assert "    ```python\n    x = [1, 2, 3]\n    ```" in formatted
     assert "        ```python\n        y = [4, 5, 6]\n        ```" in formatted
+
+
+def test_different_info_strings():
+    markdown_content = Path("tests/info_strings.md").read_text()
+    formatter = Formatter()
+    formatted = formatter.format_markdown_content(
+        file_name="", content=dedent(markdown_content)
+    )
+    assert "```python\nx = [1, 2, 3]\n```" in formatted
+    assert "```py\ny = [4, 5, 6]\n```" in formatted
+    assert "```Python\nz = [7, 8, 9]\n```" in formatted
+    assert "```python startline=3 $%@#$\na = [10, 11, 12]\n```" in formatted


### PR DESCRIPTION
The info string (i.e. language type) specified for a fenced code block does not have to be lowercase.
This pull request extends the regex in the formatter to also include the case of `Python`.

The change is covered by a simple test case.