### PR TITLE
Use sys.executable in subprocesses to ensure same interpreter is used.

### DIFF
--- a/md_snakeoil/apply.py
+++ b/md_snakeoil/apply.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import sys
 from pathlib import Path
 from textwrap import dedent, indent
 
@@ -47,6 +48,8 @@ class Formatter:
             # format code with ruff
             formatted = subprocess.check_output(
                 [
+                    sys.executable,
+                    "-m",
                     "ruff",
                     "format",
                     "--line-length",
@@ -61,6 +64,8 @@ class Formatter:
                 # lint code with ruff
                 linted = subprocess.check_output(
                     [
+                        sys.executable,
+                        "-m",
                         "ruff",
                         "check",
                         f"--select={",".join([*self.rules])}",


### PR DESCRIPTION
Hi there!

I ran into a snag while trying out the package, and wound up with these changes as the solution. The scenario will require some explaining, but the root problem was that the `subprocess.check_output` calls were using the system python instead of the venv's python that installed `md-snakeoil` (and hence `ruff`), so `ruff` was not available. Calling `ruff` using `sys.executable` fixed that for me.

Now.. the scenario this happened in is a bit odd; it was a combination of me being new to python (ie. trying dumb things) and me trying to use `md-snakeoil` in the same way the project I was looking at uses other linting tools (ie. as a module in a Makefile, not on CLI). So I don't think this is an intended scenario, but the fix seemed like it could be helpful regardless :shrug: If not, please just tell me off; this was a good learning experience either way.



Essentially, the project was installing dependencies in a venv, but was calling them (using the venv's python) from outside the venv. So when I did that with `md-snakeoil`, it used the venv's python, but `subprocess.check_output` picked up the system python.

A minimal case is:

```console
me@:$ python3 -m venv venv
me@:$ venv/bin/pip3 install md-snakeoil
me@:$ venv/bin/python3 -m md_snakeoil.cli ...
FileNotFoundError: [Errno 2] No such file or directory: 'ruff'
```

Using `sys.executable` seems to be the recommendation for "maximum reliablity" ([reference, see warning](https://docs.python.org/3/library/subprocess.html#subprocess.Popen); [another ref](https://github.com/pypa/virtualenv/pull/1080#issuecomment-329721334)), so it would ensure the same venv is used for `ruff` as was used for `md-snakeoil` ...even in oddball cases :fearful:  