### PR TITLE
Add `--check` mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,17 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # pin `uv` version
+          version: "0.11.16"
 
       # respects pinned version in the project
       - name: Set up Python
         run: uv python install
 
       - name: Install the project
-        run: uv sync --frozen
+        run: uv sync --locked --no-dev
   
       - name: Build
         run: uv build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # pin `uv` version
+          version: "0.11.16"
+
+      - name: Install the project
+        run: uv sync --locked --dev
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,14 +25,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          enable-cache: true
           # pin `uv` version
           version: "0.11.16"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install the project
         run: uv sync --locked --dev
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
         
       - name: Test with python ${{ matrix.python-version }}
         run: uv run --frozen pytest

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To run `md-snakeoil` with `pre-commit` add following to your
 ```yaml
 repos:
   - repo: https://github.com/JakobKlotz/md-snakeoil
-    rev: v0.1.7
+    rev: v0.1.9
     hooks:
       - id: snakeoil
 ```
@@ -67,21 +67,22 @@ The package provides a command-line interface (CLI) using `typer`.
 snakeoil --help
 ```
 
-```                                                                                                                                                                                                                                                                                                   
- Usage: snakeoil [OPTIONS] [PATH] COMMAND [ARGS]...                                                                                              
+```                                                                                                                  
+ Usage: snakeoil [OPTIONS] [PATH]                                                                                            
                                                                                                                                                  
- Format and lint Python code blocks in Markdown files.
+ Format & lint Markdown files. Either a single file or all files in a directory,
 
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│   path      [PATH]  File or directory to format [default: None]                                                                               │
+│   path      [PATH]  File or directory to process                                                                                              │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --line-length               INTEGER  Maximum line length for the formatted code [default: 79]                                                 │
 │ --rules                     TEXT     Ruff rules to apply (comma-separated) [default: I,W]                                                     │
+│ --check --no-check                   Check if files would be reformatted without writing changes [default: no-check]                          │
 │ --install-completion                 Install completion for the current shell.                                                                │
 │ --show-completion                    Show completion for the current shell, to copy it or customize the installation.                         │
 │ --help                               Show this message and exit.                                                                              │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 By default, the line length is set to 79 characters, and the Ruff rules `W` and
@@ -107,18 +108,10 @@ For example, format the example files within the `tests/` directory
 (of this repository):
 
 ```bash
-snakeoil tests/examples
-```
+> snakeoil tests/examples
 
-```bash
-Formatting files... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
-         Results for tests\examples
-┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
-┃ Directory      ┃ File            ┃ Status ┃
-┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
-│ tests\examples │ indentation.md  │ ✅     │
-│ tests\examples │ info_strings.md │ ✅     │
-│ tests\examples │ test.md         │ ✅     │
-└────────────────┴─────────────────┴────────┘
-All 3 files formatted successfully. ✨
+Formatted: tests\examples\indentation.md
+Formatted: tests\examples\info_strings.md
+Formatted: tests\examples\test.md
+3 formatted, 0 already formatted.
 ```

--- a/md_snakeoil/apply.py
+++ b/md_snakeoil/apply.py
@@ -10,8 +10,10 @@ class Formatter:
     Format and lint Python code blocks within markdown files.
 
     Args:
-        line_length: Maximum line length for formatted code
-        rules: Tuple of rules to apply during linting
+        line_length (int): Maximum line length for formatted code.
+            Defaults to 79.
+        rules (tuple[str, ...]): Tuple of rules to apply during linting.
+            Default ("I", "W").
     """
 
     def __init__(
@@ -143,16 +145,25 @@ class Formatter:
         inplace: bool = True,
         output_path: str | Path | None = None,
         quiet: bool = True,
-    ) -> None:
+        check: bool = False,
+    ) -> bool | None:
         """
         Format Python code blocks in a markdown file.
 
         Args:
-            file_path: Markdown file path
-            inplace: If True, update the file in place
-            output_path: If provided, write formatted content to this path
-                        (ignored if inplace=True)
-            quiet: If True, suppress ruff output
+            file_path (str | Path): Markdown file path
+            inplace (bool): Whether to update the file in place.
+                Defaults to `True`.
+            output_path (str | Path): If provided, write formatted content to
+                this path (ignored if `inplace=True`). By default `None`.
+            quiet (bool): Whether to suppress `ruff` output. Defaults to
+                `True`.
+            check (bool): Check if files would be reformatted without writing
+                changes. Defaults to `False`.
+
+        Returns:
+            bool | None: Boolean if `check=True` indicating if the content
+                changed, else `None`.
         """
         if not inplace and output_path is None:
             raise ValueError("Provide an output_path if inplace=False.")
@@ -163,7 +174,12 @@ class Formatter:
             file_name=str(file_path), content=markdown, quiet=quiet
         )
 
+        if check:
+            return formatted_content != markdown
+
         if inplace:
             self.write_markdown(formatted_content, file_path)
         else:
             self.write_markdown(formatted_content, Path(output_path))
+
+        return None

--- a/md_snakeoil/apply.py
+++ b/md_snakeoil/apply.py
@@ -146,7 +146,7 @@ class Formatter:
         output_path: str | Path | None = None,
         quiet: bool = True,
         check: bool = False,
-    ) -> bool | None:
+    ) -> tuple[bool, str]:
         """
         Format Python code blocks in a markdown file.
 
@@ -162,8 +162,8 @@ class Formatter:
                 changes. Defaults to `False`.
 
         Returns:
-            bool | None: Boolean if `check=True` indicating if the content
-                changed, else `None`.
+            tuple[bool, str]: Indicating if the content changed and
+                appropriate message.
         """
         if not inplace and output_path is None:
             raise ValueError("Provide an output_path if inplace=False.")
@@ -173,13 +173,17 @@ class Formatter:
         formatted_content = self.format_markdown_content(
             file_name=str(file_path), content=markdown, quiet=quiet
         )
+        has_changed = formatted_content != markdown
 
-        if check:
-            return formatted_content != markdown
-
-        if inplace:
-            self.write_markdown(formatted_content, file_path)
+        if not has_changed:
+            msg = f"{file_path} already formatted!"
+        elif check:
+            msg = f"Would reformat: {file_path}"
         else:
-            self.write_markdown(formatted_content, Path(output_path))
+            if inplace:
+                self.write_markdown(formatted_content, file_path)
+            else:
+                self.write_markdown(formatted_content, Path(output_path))
+            msg = f"Formatted: {file_path}"
 
-        return None
+        return has_changed, msg

--- a/md_snakeoil/cli.py
+++ b/md_snakeoil/cli.py
@@ -2,10 +2,6 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich import print as rich_print
-from rich.console import Console
-from rich.progress import track
-from rich.table import Table
 
 from md_snakeoil.apply import Formatter
 
@@ -34,9 +30,17 @@ def main(
             help="Ruff rules to apply (comma-separated)",
         ),
     ] = "I,W",
+    check: Annotated[
+        bool,
+        typer.Option(
+            help="Check if files would be reformatted without writing changes"
+        ),
+    ] = False,
 ):
-    """Format & lint Markdown files - either a single file or all files
-    in a directory."""
+    """
+    Format & lint Markdown files. Either a single file or all files in a
+    directory,
+    """
     if path is None:
         typer.echo(
             "Error: Please provide a path to a file or directory", err=True
@@ -53,8 +57,8 @@ def main(
 
     # single file
     if path.is_file():
-        formatter.run(path, inplace=True, quiet=True)
-        typer.echo(f"Formatted {path}")
+        _, msg = formatter.run(path, inplace=True, check=check)
+        typer.echo(msg)
 
     # process the directory
     else:
@@ -63,40 +67,32 @@ def main(
             typer.echo(f"No Markdown files found in {path}")
             raise typer.Exit(0)
 
-        # track processed files and display overview results as table
-        n_errors = 0
-        table = Table(
-            "Directory",
-            "File",
-            "Status",
-            title=f"Results for {path}",
-        )
-
-        for markdown_file in track(files, description="Formatting files..."):
+        files_changed = []
+        errors = 0
+        for markdown_file in files:
             try:
-                formatter.run(markdown_file, inplace=True)
-                status = ":white_check_mark:"
+                has_changed, msg = formatter.run(
+                    markdown_file, inplace=True, check=check
+                )
+                files_changed.append(has_changed)
             except UnicodeDecodeError:
-                status = (":cross_mark: Decode Error",)
-                n_errors += 1
+                msg = f"{markdown_file} :cross_mark: Decode Error"
+                errors += 1
             except Exception as e:
-                status = f":cross_mark: {str(e)[:30]}..."
-                n_errors += 1
+                msg = f"{markdown_file} :cross_mark: {str(e)[:30]}..."
+                errors += 1
+            print(msg)
 
-            # add processing result to table
-            table.add_row(
-                str(markdown_file.parent), markdown_file.name, status
-            )
-
-        Console().print(table)
-
-        # summary message
-        if n_errors > 0:
-            rich_print(f"{n_errors} files could not be formatted. :warning:")
-        else:
-            rich_print(
-                f"All {len(files)} files formatted successfully. :sparkles:"
-            )
+        sum_files_changed, n_files = sum(files_changed), len(files)
+        print(
+            f"{sum_files_changed} "
+            f"{'would be reformatted' if check else 'formatted'}, "
+            f"{n_files - sum_files_changed - errors} already formatted."
+        )
+        if errors:
+            print(f"{errors} errors.")
+        if sum_files_changed and check:
+            raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.0,<0.11.0"]
+requires = ["uv_build>=0.10.0,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "md_snakeoil"
-version = "0.1.8"
+version = "0.1.9"
 description = "Format and lint Python code blocks within markdown files."
 readme = "README.md"
 authors = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_single_markdown(test_file):
     file_name = str(test_file("copy.md"))
     result = runner.invoke(app, [file_name])
     assert result.exit_code == 0
-    assert f"Formatted {file_name}" in result.output, result
+    assert f"Formatted: {file_name}" in result.output, result
 
     # another run with different options
     file_name = str(test_file("another-copy.md"))
@@ -61,7 +61,15 @@ def test_single_markdown(test_file):
         app, [file_name, "--line-length", "120", "--rules", "E,F"]
     )
     assert result.exit_code == 0
-    assert f"Formatted {file_name}" in result.output, result
+    assert f"Formatted: {file_name}" in result.output, result
+
+
+def test_single_markdown_check(test_file):
+    """Single markdown using the check option."""
+    file_name = str(test_file("_.md"))
+    result = runner.invoke(app, [file_name, "--check"])
+    assert result.exit_code == 0
+    assert f"Would reformat: {file_name}"
 
 
 def test_directory_processing():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,24 @@
-import shutil
 import tempfile
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from md_snakeoil.cli import app
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def test_file(tmp_path):
+    example_markdown = Path("tests/examples/test.md").read_text()
+
+    def _make_test_file(name: str) -> Path:
+        f = tmp_path / name
+        f.write_text(example_markdown)
+        return f
+
+    return _make_test_file
 
 
 def test_no_path_provided():
@@ -35,29 +47,21 @@ def test_nonexistent_path():
     assert result.exit_code == 2  # Typer's default for invalid argument
 
 
-def test_single_markdown():
+def test_single_markdown(test_file):
     """Test processing a single markdown."""
     # Make a temporary copy
-    copy = Path("tests/examples/test_copy.md")
-    shutil.copy(Path("tests/examples/test.md"), copy)
-
-    result = runner.invoke(app, [str(copy)])
+    file_name = str(test_file("copy.md"))
+    result = runner.invoke(app, [file_name])
     assert result.exit_code == 0
-    assert f"Formatted {copy}" in result.output, result
-
-    # clean up
-    copy.unlink()
+    assert f"Formatted {file_name}" in result.output, result
 
     # another run with different options
-    shutil.copy(Path("tests/examples/test.md"), copy)
+    file_name = str(test_file("another-copy.md"))
     result = runner.invoke(
-        app, [str(copy), "--line-length", "120", "--rules", "E,F"]
+        app, [file_name, "--line-length", "120", "--rules", "E,F"]
     )
     assert result.exit_code == 0
-    assert f"Formatted {copy}" in result.output, result
-
-    # clean up
-    copy.unlink()
+    assert f"Formatted {file_name}" in result.output, result
 
 
 def test_directory_processing():

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -92,8 +92,9 @@ def test_different_info_strings(formatter):
 
 def test_check_mode(formatter, test_file, example_markdown):
     # With an unformatted file
-    has_changed = formatter.run(test_file, check=True)
-    assert isinstance(has_changed, bool)
+    has_changed, msg = formatter.run(test_file, check=True)
+    assert has_changed
+    assert msg == f"Would reformat: {test_file}"
 
     # Check if the file was left untouched
     assert test_file.read_text() == example_markdown
@@ -101,5 +102,6 @@ def test_check_mode(formatter, test_file, example_markdown):
     # With a formatted file
     formatter.run(test_file, inplace=True)
     # Perform a check
-    has_changed = formatter.run(test_file, check=True)
+    has_changed, msg = formatter.run(test_file, check=True)
     assert not has_changed
+    assert msg == f"{test_file} already formatted!"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -11,21 +11,30 @@ def example_markdown():
     return Path("tests/examples/test.md").read_text()
 
 
-def test_read_markdown(example_markdown):
-    formatter = Formatter()
+@pytest.fixture
+def formatter():
+    return Formatter()
+
+
+@pytest.fixture
+def test_file(tmp_path, example_markdown):
+    f = tmp_path / "copy.md"
+    f.write_text(example_markdown)
+    return f
+
+
+def test_read_markdown(formatter, example_markdown):
     content = formatter.read_markdown("tests/examples/test.md")
     assert content == example_markdown
 
 
-def test_format_single_block():
-    formatter = Formatter()
+def test_format_single_block(formatter):
     code = "x = [1,2,344,    3]"
     formatted = formatter.format_single_block(code)
     assert formatted == "x = [1, 2, 344, 3]"
 
 
-def test_format_markdown_content(example_markdown):
-    formatter = Formatter()
+def test_format_markdown_content(formatter, example_markdown):
     formatted_content = formatter.format_markdown_content(
         file_name="test.md", content=example_markdown
     )
@@ -42,22 +51,14 @@ def test_format_markdown_content(example_markdown):
     assert '{"a": 1, "b": 2, "f": 323}' in formatted_content
 
 
-def test_run_inplace(tmp_path, example_markdown):
-    formatter = Formatter()
-    test_file = tmp_path / "copy.md"
-    test_file.write_text(example_markdown)
-
+def test_run_inplace(formatter, test_file, example_markdown):
     formatter.run(test_file, inplace=True)
 
     # check if the file was updated in-place
     assert test_file.read_text() != example_markdown
 
 
-def test_run_output_file(tmp_path, example_markdown):
-    formatter = Formatter()
-    test_file = tmp_path / "copy.md"
-    test_file.write_text(example_markdown)
-
+def test_run_output_file(formatter, test_file, tmp_path, example_markdown):
     output_file = tmp_path / "formatted_index.md"
     formatter.run(test_file, output_path=output_file, inplace=False)
 
@@ -67,10 +68,9 @@ def test_run_output_file(tmp_path, example_markdown):
     assert "x = [1, 2, 344, 3]" in output_file.read_text()
 
 
-def test_different_indentation_levels():
+def test_different_indentation_levels(formatter):
     markdown_content = Path("tests/examples/indentation.md").read_text()
 
-    formatter = Formatter()
     formatted = formatter.format_markdown_content(
         file_name="", content=dedent(markdown_content)
     )
@@ -79,9 +79,8 @@ def test_different_indentation_levels():
     assert "        ```python\n        y = [4, 5, 6]\n        ```" in formatted
 
 
-def test_different_info_strings():
+def test_different_info_strings(formatter):
     markdown_content = Path("tests/examples/info_strings.md").read_text()
-    formatter = Formatter()
     formatted = formatter.format_markdown_content(
         file_name="", content=dedent(markdown_content)
     )
@@ -91,12 +90,8 @@ def test_different_info_strings():
     assert "```python startline=3 $%@#$\na = [10, 11, 12]\n```" in formatted
 
 
-def test_check_mode(tmp_path, example_markdown):
+def test_check_mode(formatter, test_file, example_markdown):
     # With an unformatted file
-    formatter = Formatter()
-    test_file = tmp_path / "copy.md"
-    test_file.write_text(example_markdown)
-
     has_changed = formatter.run(test_file, check=True)
     assert isinstance(has_changed, bool)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -89,3 +89,22 @@ def test_different_info_strings():
     assert "```py\ny = [4, 5, 6]\n```" in formatted
     assert "```Python\nz = [7, 8, 9]\n```" in formatted
     assert "```python startline=3 $%@#$\na = [10, 11, 12]\n```" in formatted
+
+
+def test_check_mode(tmp_path, example_markdown):
+    # With an unformatted file
+    formatter = Formatter()
+    test_file = tmp_path / "copy.md"
+    test_file.write_text(example_markdown)
+
+    has_changed = formatter.run(test_file, check=True)
+    assert isinstance(has_changed, bool)
+
+    # Check if the file was left untouched
+    assert test_file.read_text() == example_markdown
+
+    # With a formatted file
+    formatter.run(test_file, inplace=True)
+    # Perform a check
+    has_changed = formatter.run(test_file, check=True)
+    assert not has_changed

--- a/uv.lock
+++ b/uv.lock
@@ -13,14 +13,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -43,14 +43,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -87,11 +87,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -105,16 +105,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -123,47 +123,47 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
 name = "rich"
-version = "14.3.2"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.15.0"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -185,7 +185,7 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/e6/44e073787aa57cd71c151f44855232feb0f748428fd5242d7366e3c4ae8b/typer-0.23.0.tar.gz", hash = "sha256:d8378833e47ada5d3d093fa20c4c63427cc4e27127f6b349a6c359463087d8cc", size = 120181, upload-time = "2026-02-11T15:22:18.637Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ed/d6fca788b51d0d4640c4bc82d0e85bad4b49809bca36bf4af01b4dcb66a7/typer-0.23.0-py3-none-any.whl", hash = "sha256:79f4bc262b6c37872091072a3cb7cb6d7d79ee98c0c658b4364bdcde3c42c913", size = 56668, upload-time = "2026-02-11T15:22:21.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "md-snakeoil"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "ruff" },


### PR DESCRIPTION
Adds a `--check` flag to the CLI that reports which files would be reformatted and linted without writing any changes. The exit code reflects whether any changes were detected, making it suitable for use in CI pipelines.